### PR TITLE
ci(dependbotautomerge): fix what string to check for in pull request title

### DIFF
--- a/.github/workflows/dependbotAutomerge.yml
+++ b/.github/workflows/dependbotAutomerge.yml
@@ -11,7 +11,7 @@ jobs:
       startsWith(github.actor, 'dependabot') &&
       github.event_name == 'pull_request' &&
       (startsWith(github.event.pull_request.title, 'build(deps):') ||
-      startsWith(github.event.pull_request.title, 'build(dev-deps):'))
+      startsWith(github.event.pull_request.title, 'build(devDep):'))
     steps:
       - name: '@dependabot squash and merge'
         uses: actions/github-script@v2


### PR DESCRIPTION
The github action wasn't matching the prefix for dev dependencies.