### PR TITLE
ci(semantic-release): remove results when running @google/semantic-re…

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -12,15 +12,6 @@ module.exports = {
             files: ['package.json'],
             from: '"version": ".*"',
             to: '"version": "${nextRelease.version}"',
-            results: [
-              {
-                file: 'package.json',
-                hasChanged: true,
-                numMatches: 1,
-                numReplacements: 1,
-              },
-            ],
-            countMatches: true,
           },
         ],
       },


### PR DESCRIPTION
…lease-replace-plugin plugin

It's shouldn't cause it to fail if the version has not changed