### PR TITLE
fix(github-actions): fix the command used when extracting next semantic-version number

### DIFF
--- a/.github/workflows/androidBuild.yml
+++ b/.github/workflows/androidBuild.yml
@@ -135,11 +135,13 @@ jobs:
           printf 'API_KEY=%s\n' '${{ secrets.API_KEY }}' >> .env
 
       - name: Update semantic-version in package.json
+        # NOTE: this will run successfully on master branch. on any other branch it will use the current npm version
         # run semantic-version in dry-run mode
         # extract string that starts with "Release note"
         # extract version number
         # update version using "npm version"
-        run: yarn semantic-release -d | egrep 'Release note' | egrep -o '(\d+)\.(\d+)\.(\d+)' | xargs npm version --allow-same-version --no-git-tag-version --force
+        run: |
+          yarn semantic-release -d | grep 'Release note' | grep -Po "(\d+)\.(\d+)\.(\d+)" | xargs npm version --allow-same-version --no-git-tag-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Problem: using egrep to extract version number causes to return error code.

Solution: use 'grep -P' to use regex notation.
check: https://stackoverflow.com/a/63589181/3053548