### PR TITLE
fix(android): add extra heap space when building Android APK

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -131,6 +131,12 @@ def keyStoreProperties = new Properties()
 keyStoreProperties.load(new FileInputStream(keyStorePropertiesFile))
 
 android {
+    // set heap space when building Android APK
+    // https://stackoverflow.com/a/60026260/3053548
+    dexOptions {
+      javaMaxHeapSize "4g"
+    }
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -26,3 +26,7 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.33.1
+
+# set heap space when building android APK
+# https://stackoverflow.com/a/60026260/3053548
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
When running androidBuild github actions workflow, sometimes it fails to build successfully due to
small heap space.

check https://stackoverflow.com/a/60026260/3053548